### PR TITLE
Enable copy-and-paste for text areas in Firefox.

### DIFF
--- a/bantam-service/src/Bantam/Service/View/Fight.hs
+++ b/bantam-service/src/Bantam/Service/View/Fight.hs
@@ -69,7 +69,7 @@ lemmaReadView l =
     H.textarea
       ! HA.class_ "form-control lemma"
       ! HA.name "lemma"
-      ! HA.disabled "true"
+      ! HA.readonly "true"
       $
       toHtml . renderLemma $ l
 
@@ -88,7 +88,7 @@ reviewView fid lid lemma =
         H.textarea
           ! HA.class_ "form-control lemma"
           ! HA.name "lemma"
-          ! HA.disabled "true"
+          ! HA.readonly "true"
           $
           toHtml . renderLemma $ lemma
 


### PR DESCRIPTION
Firefox doesn't allow selection of text in `disabled` text areas. The `readonly` attribute serves much the same purpose whilst also allowing selection.

See also: https://bugzilla.mozilla.org/show_bug.cgi?id=253870

(I didn't check that this compiles because I'm a `mafia` noob and ran into some cabal dependency issues)
